### PR TITLE
JSONStream.parse does not detect error listeners

### DIFF
--- a/replicator.js
+++ b/replicator.js
@@ -15,7 +15,7 @@ module.exports = function (givenOptions, callback) {
     Replicator.replicateFromSnapShotStream = function (readStream, callback) {
       var indexesws = levelws(indexes);
       readStream.pipe(zlib.createGunzip())
-        .pipe(JSONStream.parse())
+        .pipe(JSONStream.parse().on('error', callback))
         .pipe(indexesws.createWriteStream())
         .on('close', callback)
         .on('error', function(err) {

--- a/replicator.js
+++ b/replicator.js
@@ -18,9 +18,7 @@ module.exports = function (givenOptions, callback) {
         .pipe(JSONStream.parse().on('error', callback))
         .pipe(indexesws.createWriteStream())
         .on('close', callback)
-        .on('error', function(err) {
-          console.log(err)
-        });
+        .on('error', callback);
     };
 
     //ReplicateFromBatch


### PR DESCRIPTION
If you have an `.on('error', cb)` on a stream that has a `JSONStream.parse` in the pipe and something in that part errors, it will not go out to the listener on the stream. It has to be attached directly to the `JSONStream.parse()` stream.

This is related to #1 