### PR TITLE
zlib.createGunzip does not detect error listeners

### DIFF
--- a/replicator.js
+++ b/replicator.js
@@ -14,7 +14,7 @@ module.exports = function (givenOptions, callback) {
     //ReplicateFromStream
     Replicator.replicateFromSnapShotStream = function (readStream, callback) {
       var indexesws = levelws(indexes);
-      readStream.pipe(zlib.createGunzip())
+      readStream.pipe(zlib.createGunzip().on('error', callback))
         .pipe(JSONStream.parse().on('error', callback))
         .pipe(indexesws.createWriteStream())
         .on('close', callback)


### PR DESCRIPTION
Errors during `createGunzip` don't get caught by the outer error handler, so another `.on('error')` has to go on `createGunzip` itself.

Fixes https://github.com/fergiemcdowall/search-index-replicator/issues/3
